### PR TITLE
Fix mirror unit test buffer panic.

### DIFF
--- a/vflow/ipfix_test.go
+++ b/vflow/ipfix_test.go
@@ -30,7 +30,9 @@ import (
 )
 
 func init() {
-	opts = &Options{}
+	opts = &Options{
+		IPFIXUDPSize: 1500,
+	}
 }
 
 func TestMirrorIPFIX(t *testing.T) {
@@ -91,7 +93,8 @@ func TestMirrorIPFIX(t *testing.T) {
 		return
 	}
 
-	body := []byte("hello")
+	body := ipfixBuffer.Get().([]byte)
+	body = append(body[:0], []byte("hello")...)
 
 	msg <- IPFIXUDPMsg{
 		body: body,


### PR DESCRIPTION
This PR fixes the panic when running the unit test `TestMirrorIPFIX` by setting the default value for `IPFIXUDPSize`.
```
=== RUN   TestMirrorIPFIX
panic: runtime error: slice bounds out of range [:20] with capacity 0

goroutine 20 [running]:
github.com/EdgeCast/vflow/vflow.mirrorIPFIX({0xc0000a0240, 0x10, 0x10}, 0x2728, 0x0)
        /vflow/vflow/ipfix_unix.go:112 +0x6b5
github.com/EdgeCast/vflow/vflow.TestMirrorIPFIX.func1()
        /vflow/vflow/ipfix_test.go:45 +0x45
created by github.com/EdgeCast/vflow/vflow.TestMirrorIPFIX
        /vflow/vflow/ipfix_test.go:44 +0x12f
FAIL    github.com/EdgeCast/vflow/vflow 2.039s
FAIL
make: *** [test] Error 1
```